### PR TITLE
Improve BLE stability and battery reporting

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -15,7 +15,9 @@
 
 // Pin configuration for reading battery voltage.
 #define BATTERY_ANALOG_PIN 21  ///< Analog pin used for reading battery voltage.
-#define BATTERY_MAX_READING 1024.0  ///< Maximum ADC reading for battery.
+#define ANALOG_READ_RESOLUTION_BITS 12  ///< ADC resolution used for battery readings.
+#define BATTERY_MAX_READING 4095.0  ///< Maximum ADC reading for the configured resolution.
+#define BATTERY_SAMPLE_COUNT 8  ///< Number of samples taken to smooth the battery reading.
 #define BATTERY_MIN_VOLTAGE 7  ///< Minimum voltage considered for the battery.
 #define BATTERY_MAX_VOLTAGE 8.4  ///< Maximum voltage for a fully charged battery.
 #define R1 30000.0  ///< Resistance value R1 in Ohms.
@@ -31,6 +33,13 @@
 #define EFFECT_SERVICE_UUID "0A92"  ///< UUID for the effect service.
 #define SCOLOR_SERVICE_UUID "0A93"  ///< UUID for the solid color service.
 #define ENERGY_SERVICE_UUID "0A95"  ///< UUID for the energy saving service.
+#define SOLID_COLOR_DEFAULT_VALUE "NO COLOR"  ///< Default value used for the solid color characteristic.
+#define SOLID_COLOR_MAX_LENGTH 8  ///< Maximum length for the solid color characteristic string.
+#define DEFAULT_EFFECT_VALUE 255  ///< Default value used for the effect characteristic (idle state).
+#define DEFAULT_ENERGY_SAVING_MODE 0  ///< Default energy-saving mode value.
+#define ENERGY_SAVING_MAX_LEVEL 8  ///< Maximum allowed energy-saving mode level.
+#define BLE_DEVICE_APPEARANCE 0x04C0  ///< BLE appearance code for LED toys.
+#define BLE_ADVERTISING_INTERVAL 152  ///< Advertising interval in units of 0.625 ms.
 #define MANUFACTURER_CHARACTERISTIC "OpenHoop"  ///< Manufacturer characteristic.
 #define MODEL_CHARACTERISTIC "HulaHoopBLE"  ///< Model characteristic.
 #define SERIAL_NUMBER_CHARACTERISTIC "HH-BLE-1"  ///< Serial number characteristic.

--- a/include/services/BleService.h
+++ b/include/services/BleService.h
@@ -29,8 +29,9 @@ public:
 
     /**
      * @brief Initializes and advertises the BLE service.
+     * @return True if the BLE stack started advertising successfully, otherwise false.
      */
-    void beginAndAdvertise();
+    bool beginAndAdvertise();
 
     /**
      * @brief Updates the battery level characteristic.
@@ -41,6 +42,13 @@ public:
     BLEByteCharacteristic effectCharacteristic;  ///< Effect characteristic for BLE.
     BLEStringCharacteristic solidColorCharacteristic;  ///< Solid color characteristic for BLE.
     BLEByteCharacteristic energySavingModeCharacteristic;  ///< Energy-saving mode characteristic.
+
+    /**
+     * @brief Resets controllable characteristics to their default values.
+     */
+    void resetControlCharacteristics();
+
+    static constexpr uint8_t SOLID_COLOR_VALUE_SIZE = 8;  ///< Length reserved for the solid color payload.
 
 private:
     BLEService hulaHoopService;  ///< Hula Hoop service for BLE.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,12 +15,42 @@
 #include "../include/utils/EffectUtils.h"
 #include "../include/Config.h"
 
+namespace {
+constexpr unsigned long kBatteryUpdateIntervalMs = 1000UL;
+constexpr uint8_t kBatterySampleCount = BATTERY_SAMPLE_COUNT;
+constexpr float kAdcToVoltage = REF_VOLTAGE / BATTERY_MAX_READING;
+constexpr float kVoltageDividerRatio = (R1 + R2) / R2;
+constexpr uint8_t kMaxEnergySavingLevel = ENERGY_SAVING_MAX_LEVEL;
+constexpr uint8_t kColorBufferSize = BleService::SOLID_COLOR_VALUE_SIZE + 1;
+
+unsigned long lastBatteryUpdateMs = 0;
+bool isCentralConnected = false;
+
+constexpr bool isValidEffect(uint8_t effectValue) {
+    return (effectValue <= static_cast<uint8_t>(EffectType::MUSHROOM)) ||
+           (effectValue == static_cast<uint8_t>(EffectType::PULSE)) ||
+           (effectValue == static_cast<uint8_t>(EffectType::SPECTRUM));
+}
+
+uint8_t clampEnergySavingLevel(uint8_t level) {
+    return level > kMaxEnergySavingLevel ? kMaxEnergySavingLevel : level;
+}
+} // namespace
+
 HulaHoopDotStar hoop(NUM_LEDS, LEDS_DATA_PIN, LEDS_CLOCK_PIN);
 
 BleService bleService;
 std::unique_ptr<EffectService> effectService = std::make_unique<EffectService>();
 
 void setup() {
+    Serial.begin(115200);
+    unsigned long serialStart = millis();
+    while (!Serial && (millis() - serialStart) < 2000UL) {
+        delay(10);
+    }
+
+    analogReadResolution(ANALOG_READ_RESOLUTION_BITS);
+
     // Initialize the PDM library for sound processing
     PDM.onReceive(EffectUtils::onPDMdata);
 
@@ -29,7 +59,13 @@ void setup() {
     hoop.show();
 
     // Initialize DotStar BLE services
-    bleService.beginAndAdvertise();
+    if (!bleService.beginAndAdvertise()) {
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    lastBatteryUpdateMs = millis() - kBatteryUpdateIntervalMs;
 }
 
 /**
@@ -37,29 +73,45 @@ void setup() {
  * Handles color code writes, gesture commands, and energy-saving mode changes.
  */
 void updateBLE() {
+    BLE.poll();
+
     BLEDevice central = BLE.central();
-    // Check for color code writes
-    if (bleService.solidColorCharacteristic.written()) {
-        String colorString = bleService.solidColorCharacteristic.value();
-        effectService->dispatchSolidColorCommand(colorString);
-        Serial.print("Color Command Received: ");
-        Serial.println(colorString);
-        bleService.effectCharacteristic.writeValue(-1);
-    }
+    if (central && central.connected()) {
+        if (!isCentralConnected) {
+            isCentralConnected = true;
+        }
 
-    // Check for gesture commands
-    if (bleService.effectCharacteristic.written()) {
-        auto gesture = static_cast<EffectType>(bleService.effectCharacteristic.value());
-        effectService->dispatchEffectCommand(gesture);
-        Serial.print("Effect Command Received: ");
-        Serial.println(static_cast<int>(gesture));
-        bleService.solidColorCharacteristic.writeValue("NO COLOR");
-    }
+        if (bleService.solidColorCharacteristic.written()) {
+            char colorBuffer[kColorBufferSize] = {};
+            const int length = bleService.solidColorCharacteristic.readValue(colorBuffer, BleService::SOLID_COLOR_VALUE_SIZE);
+            if (length > 0) {
+                colorBuffer[length < BleService::SOLID_COLOR_VALUE_SIZE ? length : BleService::SOLID_COLOR_VALUE_SIZE] = '\0';
+                effectService->dispatchSolidColorCommand(String(colorBuffer));
+                bleService.effectCharacteristic.writeValue(DEFAULT_EFFECT_VALUE);
+            }
+        }
 
-    // Check for energy-saving mode writes
-    if (bleService.energySavingModeCharacteristic.written()) {
-        uint8_t energySavingMode = bleService.energySavingModeCharacteristic.value();
-        hoop.setEnergySavingMode(energySavingMode);
+        if (bleService.effectCharacteristic.written()) {
+            const uint8_t effectValue = bleService.effectCharacteristic.value();
+            if (isValidEffect(effectValue)) {
+                effectService->dispatchEffectCommand(static_cast<EffectType>(effectValue));
+                bleService.solidColorCharacteristic.writeValue(SOLID_COLOR_DEFAULT_VALUE);
+            }
+        }
+
+        if (bleService.energySavingModeCharacteristic.written()) {
+            const uint8_t requestedMode = bleService.energySavingModeCharacteristic.value();
+            const uint8_t clampedMode = clampEnergySavingLevel(requestedMode);
+            hoop.setEnergySavingMode(clampedMode);
+            if (clampedMode != requestedMode) {
+                bleService.energySavingModeCharacteristic.writeValue(clampedMode);
+            }
+        }
+    } else if (isCentralConnected) {
+        bleService.resetControlCharacteristics();
+        hoop.setEnergySavingMode(DEFAULT_ENERGY_SAVING_MODE);
+        BLE.advertise();
+        isCentralConnected = false;
     }
 }
 
@@ -67,9 +119,22 @@ void updateBLE() {
  * @brief Update battery level based on the analog reading.
  */
 void updateBatteryLevel() {
-    int adcValue = analogRead(BATTERY_ANALOG_PIN);
-    auto adcVoltage = static_cast<float>((adcValue * REF_VOLTAGE) / BATTERY_MAX_READING);
-    auto batteryVoltage = static_cast<float>(adcVoltage * (R1 + R2) / R2);
+    const unsigned long now = millis();
+    if ((now - lastBatteryUpdateMs) < kBatteryUpdateIntervalMs) {
+        return;
+    }
+    lastBatteryUpdateMs = now;
+
+    uint32_t accumulatedReading = 0;
+    for (uint8_t sample = 0; sample < kBatterySampleCount; ++sample) {
+        accumulatedReading += static_cast<uint32_t>(analogRead(BATTERY_ANALOG_PIN));
+        delayMicroseconds(50);
+    }
+
+    const float averageReading = static_cast<float>(accumulatedReading) / kBatterySampleCount;
+    const float adcVoltage = averageReading * kAdcToVoltage;
+    const float batteryVoltage = adcVoltage * kVoltageDividerRatio;
+
     bleService.updateBatteryLevel(batteryVoltage);
 }
 

--- a/src/services/BleService.cpp
+++ b/src/services/BleService.cpp
@@ -27,7 +27,7 @@ BleService::BleService():
         batteryService("180F"),
         batteryLevelCharacteristic("2A19", BLERead | BLENotify),
         effectCharacteristic(EFFECT_SERVICE_UUID, BLERead | BLEWrite),
-        solidColorCharacteristic(SCOLOR_SERVICE_UUID, BLERead | BLEWrite, 8),
+        solidColorCharacteristic(SCOLOR_SERVICE_UUID, BLERead | BLEWrite, SOLID_COLOR_VALUE_SIZE),
         energySavingModeCharacteristic(ENERGY_SERVICE_UUID, BLERead | BLEWrite),
         hulaHoopService("1812"),
         reportDescriptor("2908", "04 0B 00 0B 00 03 00 00 00 00 00 00 00 00 00 00 00 00 00 00"),
@@ -43,12 +43,14 @@ BleService::BleService():
 /**
  * @brief Begin BLE communication and advertise the HulaHoop device.
  */
-void BleService::beginAndAdvertise() {
-    // BLE setup
-    BLE.begin();
+bool BleService::beginAndAdvertise() {
+    if (!BLE.begin()) {
+        return false;
+    }
+
     BLE.setDeviceName(MANUFACTURER_CHARACTERISTIC);
     BLE.setLocalName(MODEL_CHARACTERISTIC);
-    BLE.setAppearance(0x04C0);
+    BLE.setAppearance(BLE_DEVICE_APPEARANCE);
     BLE.setAdvertisedService(hulaHoopService);
 
     // Configure Report Map
@@ -62,16 +64,16 @@ void BleService::beginAndAdvertise() {
             0x95, 0x01,       // Report Count (1)
             0x81, 0x02        // Input (Data, Variable, Absolute)
     };
-    for (unsigned char i : reportMap) {
-        reportMapCharacteristic.writeValue(i);
+    for (uint8_t value : reportMap) {
+        reportMapCharacteristic.writeValue(value);
     }
     hulaHoopService.addCharacteristic(reportMapCharacteristic);
     hulaHoopControlService.addCharacteristic(effectCharacteristic);
-    effectCharacteristic.writeValue(-1);
+    effectCharacteristic.writeValue(DEFAULT_EFFECT_VALUE);
     hulaHoopControlService.addCharacteristic(solidColorCharacteristic);
-    solidColorCharacteristic.writeValue("NO COLOR");
+    solidColorCharacteristic.writeValue(SOLID_COLOR_DEFAULT_VALUE);
     hulaHoopControlService.addCharacteristic(energySavingModeCharacteristic);
-    energySavingModeCharacteristic.writeValue(0);
+    energySavingModeCharacteristic.writeValue(DEFAULT_ENERGY_SAVING_MODE);
     deviceInformationService.addCharacteristic(pnpIdCharacteristic);
     deviceInformationService.addCharacteristic(manufacturerCharacteristic);
     deviceInformationService.addCharacteristic(modelCharacteristic);
@@ -98,8 +100,8 @@ void BleService::beginAndAdvertise() {
     BLE.addService(batteryService);
     BLE.addService(deviceInformationService);
 
-    BLE.setAdvertisingInterval(152);
-    BLE.advertise();
+    BLE.setAdvertisingInterval(BLE_ADVERTISING_INTERVAL);
+    return BLE.advertise();
 }
 
 /**
@@ -108,6 +110,20 @@ void BleService::beginAndAdvertise() {
  */
 void BleService::updateBatteryLevel(float voltage) {
     // Calculate the battery level and update the BLE characteristic
-    int batteryLevel = map(static_cast<long>(voltage * 100), static_cast<long>(BATTERY_MIN_VOLTAGE * 100), static_cast<long>(BATTERY_MAX_VOLTAGE * 100), 0, 100);
-    batteryLevelCharacteristic.writeValue(batteryLevel);
+    const float clampedVoltage = voltage < BATTERY_MIN_VOLTAGE ? BATTERY_MIN_VOLTAGE : (voltage > BATTERY_MAX_VOLTAGE ? BATTERY_MAX_VOLTAGE : voltage);
+    const float percent = (clampedVoltage - BATTERY_MIN_VOLTAGE) / (BATTERY_MAX_VOLTAGE - BATTERY_MIN_VOLTAGE);
+    const float boundedPercent = percent < 0.0f ? 0.0f : (percent > 1.0f ? 1.0f : percent);
+    const uint8_t batteryLevel = static_cast<uint8_t>((boundedPercent * 100.0f) + 0.5f);
+
+    static uint8_t lastReportedLevel = 0xFF;
+    if (batteryLevel != lastReportedLevel) {
+        batteryLevelCharacteristic.writeValue(batteryLevel);
+        lastReportedLevel = batteryLevel;
+    }
+}
+
+void BleService::resetControlCharacteristics() {
+    effectCharacteristic.writeValue(DEFAULT_EFFECT_VALUE);
+    solidColorCharacteristic.writeValue(SOLID_COLOR_DEFAULT_VALUE);
+    energySavingModeCharacteristic.writeValue(DEFAULT_ENERGY_SAVING_MODE);
 }


### PR DESCRIPTION
## Summary
- configure battery measurement for the Nano 33 BLE Sense with higher ADC resolution, smoothing, and throttled updates
- harden BLE connection handling by polling, clamping commands, and resetting control characteristics on disconnects
- expose helper APIs and defaults in the BLE service for reusability and cleaner setup logic

## Testing
- Not run (PlatformIO CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e9c78ace448330977eb387f52f54e2